### PR TITLE
✨ support writing bookmark data as hex to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Quick'n'dirty tool to make APFS aliases without going via AppleScript.
 ## Usage
 
 ```
-Usage: mkalias <source> <target>
+Usage: mkalias <source> [target]
 ```
+
+If `target` is omitted, the bookmark data will be printed to `stdout` in hexadecimal.
 
 ## License
 

--- a/mkalias.m
+++ b/mkalias.m
@@ -3,8 +3,8 @@
 
 int main(int argc, char **argv)
 {
-    if(argc != 3) {
-        fprintf(stderr, "Usage: %s <source> <target>\n", argv[0]);
+    if(argc < 2 || argc > 3) {
+        fprintf(stderr, "Usage: %s <source> [target]\n", argv[0]);
         return 2;
     }
 
@@ -12,10 +12,8 @@ int main(int argc, char **argv)
         NSError *error      = nil;
         NSData  *data       = nil;
         NSURL   *source_url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:argv[1]]];
-        NSURL   *target_url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:argv[2]]];
 
-        // printf("%s -> %s\n", [[source_url absoluteString] UTF8String], [[target_url absoluteString] UTF8String]);
-
+        // Generate bookmark data for the source URL
         data = [source_url bookmarkDataWithOptions:NSURLBookmarkCreationSuitableForBookmarkFile
                     includingResourceValuesForKeys:nil
                                      relativeToURL:nil
@@ -25,13 +23,30 @@ int main(int argc, char **argv)
             return 1;
         }
 
-        (void)[NSURL writeBookmarkData:data
-                                 toURL:target_url
-                               options:NSURLBookmarkCreationSuitableForBookmarkFile
-                                 error:&error];
-        if(error != nil) {
-            fprintf(stderr, "Error writing bookmark data: %s\n", [[error localizedDescription] UTF8String]);
-            return 1;
+        // Check if the target argument is provided
+        if(argc == 3) {
+            NSURL *target_url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:argv[2]]];
+
+            // Write the bookmark data to the target file
+            (void)[NSURL writeBookmarkData:data
+                                     toURL:target_url
+                                   options:NSURLBookmarkCreationSuitableForBookmarkFile
+                                     error:&error];
+            if(error != nil) {
+                fprintf(stderr, "Error writing bookmark data: %s\n", [[error localizedDescription] UTF8String]);
+                return 1;
+            }
+        } else {
+            // Print the bookmark data as a hex string if no target is provided
+            const unsigned char *bytes = [data bytes];
+            NSUInteger length = [data length];
+            NSMutableString *hexString = [NSMutableString stringWithCapacity:length * 2];
+
+            for (NSUInteger i = 0; i < length; i++) {
+                [hexString appendFormat:@"%02x", bytes[i]];
+            }
+
+            printf("%s\n", [hexString UTF8String]);
         }
     }
 


### PR DESCRIPTION
If the 2nd argument (target) is omitted, instead of error out, print the bookmark data to stdout in a hex representation.